### PR TITLE
Update actions/upload-artifact to v4

### DIFF
--- a/.github/workflows/pvmfw.yml
+++ b/.github/workflows/pvmfw.yml
@@ -44,7 +44,7 @@ jobs:
         OP13_ROM_URL: ${{ inputs.op13Url }}
 
     - name: Upload build artifact
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: output
         path: out/*.img


### PR DESCRIPTION
there is an error  with actions/upload-artifact@v3, we should upfate to v4
Missing download info for actions/upload-artifact@v3